### PR TITLE
Echo minos value of binary when compiling for macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -54,6 +54,9 @@ if(APPLE)
 	endif()
 endif()
 
+set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 # Statically link gcc/c++
 if(MSVC)
 	# /MT = Multithread, static version of the run-time library

--- a/ant/build.xml
+++ b/ant/build.xml
@@ -247,7 +247,7 @@
         </condition>
 
         <!-- Retreive minos value (macOS only) -->
-        <condition property="exec.argline" value="otool -l '${native.file.unix}' |grep minos|xargs" else="cd .">
+        <condition property="exec.argline" value="otool -l '${native.file.unix}' |grep -E -A4 '(LC_VERSION_MIN_MACOSX|LC_BUILD_VERSION)' | grep -B1 sdk" else="cd .">
             <equals arg1="${os.target.name}" arg2="osx"/>
         </condition>
 

--- a/ant/build.xml
+++ b/ant/build.xml
@@ -247,7 +247,7 @@
         </condition>
 
         <!-- Retreive minos value (macOS only) -->
-        <condition property="exec.argline" value="otool -l '${native.file.unix}' |grep minos|xargs" else="echo">
+        <condition property="exec.argline" value="otool -l '${native.file.unix}' |grep minos|xargs" else="cd .">
             <equals arg1="${os.target.name}" arg2="osx"/>
         </condition>
 

--- a/ant/build.xml
+++ b/ant/build.xml
@@ -224,7 +224,7 @@
         <echo level="info"/>
     </target>
 
-    <target name="show-file-info">
+    <target name="show-file-info" depends="main-props">
         <!-- Show binary output file information -->
         <fileset id="native.files" dir="${maven.nativelibdir.path}" includes="*"/>
         <echo level="info">File information:</echo>
@@ -239,22 +239,21 @@
         <!-- Convert path to unix format -->
         <pathconvert targetos="unix" property="native.file.unix" refid="native.files"/>
 
-        <!-- Prepare command ("file" on unix, "sh.exe" on Windows)-->
-        <condition property="exec.command" value="${git.sh}" else="file">
+        <!-- Prepare command ("sh" on unix, "sh.exe" on Windows)-->
+        <condition property="exec.command" value="${git.sh}" else="sh">
             <resourceexists>
                 <file file="${git.sh}"/>
             </resourceexists>
+        </condition>
+
+        <!-- Retreive minos value (macOS only) -->
+        <condition property="exec.argline" value="otool -l '${native.file.unix}' |grep minos|xargs" else="echo">
+            <equals arg1="${os.target.name}" arg2="osx"/>
         </condition>
 
         <!-- Prepare argument line -->
-        <condition property="exec.argline" value="-c &quot;file '${native.file.unix}'&quot;" else="'${native.file.unix}'">
-            <resourceexists>
-                <file file="${git.sh}"/>
-            </resourceexists>
-        </condition>
-
         <exec executable="${exec.command}">
-            <arg line="${exec.argline}"/>
+            <arg line="-c &quot;file '${native.file.unix}'&amp;&amp; ${exec.argline}&quot;"/>
         </exec>
         <echo level="info"></echo>
     </target>


### PR DESCRIPTION
Per https://github.com/java-native/jssc/pull/178#issuecomment-2525306826, hopefully this will give us some insight from the CI what target macOS platform our binaries are for.  Defaults to no-op for other targets.

Sample from my machine:

```
show-file-info:
     [echo] File information:
     [exec] /Users/owner/jssc/target/cmake/natives/osx_arm64/libjssc.dylib: Mach-O 64-bit dynamically linked shared library arm64
     [exec] minos 15.0
     [echo] 
```